### PR TITLE
Remove common misspelling of 'yes'

### DIFF
--- a/badwords.md
+++ b/badwords.md
@@ -910,6 +910,4 @@ wichser
 
 wop*
 
-yed
-
 zabourah


### PR DESCRIPTION
I couldn't find another widely used meaning for 'yed' and I accidentally type it pretty often.