### PR TITLE
Remove Real Name policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,6 @@ GoBridge uses the Go CoC as our base document:
 
 ## GoBridge Addendum
 
-### Name Policy
-The use of names that people use outside of the internet is important and fosters more community openness. We value names because our interactions are with real people, not some avatar or a username. We encourage all members use their full name when participating in our online communities.
-
-We also ask that members use login/usernames that are non-offensive. Your username needn't be your full name, but should not contain offensive terms.
-
 ### Language Policy
 We are working hard to keep the public spaces family friendly and as inclusive as possible. At the admins discretion, words that are deemed inappropriate or offensive will be moderated. Please reach out to the admin group for a list of words that are being moderated.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ GoBridge uses the Go CoC as our base document:
 
 ## GoBridge Addendum
 
+### Real Names
+If you feel comfortable, we encourage you to use your real name in GoBridge online communities. We find it encourages openness and civility in discussions. However, this is not a requirement.
+
 ### Language Policy
 We are working hard to keep the public spaces family friendly and as inclusive as possible. At the admins discretion, words that are deemed inappropriate or offensive will be moderated. Please reach out to the admin group for a list of words that are being moderated.
 


### PR DESCRIPTION
So-called "Real Name" policies in online communties are discriminatory toward vulnerable minorities, empirically don't impact nebulous metrics like "civility", and don't belong as part of the GoBridge CoC.

[Quoting the EFF](https://www.eff.org/deeplinks/2011/07/case-pseudonyms),

> There are myriad reasons why individuals may wish to use a name other than the one they were born with. They may be concerned about threats to their lives or livelihoods, or they may risk political or economic retribution. They may wish to prevent discrimination or they may use a name that’s easier to pronounce or spell in a given culture.

Most obviously, female and other minority community members may want to shield their identity for fear of stalking or harassment. But it is of course not limited to minorities: the mailing list has witnessed several messages from Gophers living in nations where access to information is restricted, and who may earnestly fear political or criminal retribution for participating in our communities. _Anyone_ may have legitimate, private reasons for not wanting to expose their real identity in a public forum. Having and enforcing a real name policy is discouraging to those users.

There are other, real reasons people may want or need to avoid using real names online. [Everyday Feminism](http://everydayfeminism.com/2015/09/the-problem-with-real-names/) documents several, including

- Real names may be "dead names" i.e. old names for trans people, who may not be comfortable or able to advertise their transition
- Real names may be reminders of or triggers for trauma

I understand that moderators have suggested in private messages to contributors who don't want to expose their real names that they "make up" normal-sounding first and last names. There are two major problems here. One: this isn't reflected in the on-the-record policy, and so it doesn't help potential members who are discouraged when reading the community rules; also, it creates the potential for discordant judgment from different moderators. Two: the expectation of a normal-sounding first and last name as a pseudonym carries an unfortunate and unnecessary western cultural bias that can itself be discouraging to potential members.

As an amusing, somewhat tangential point of further evidence, real name policies "[may run afoul of legal constraints](https://en.wikipedia.org/wiki/Nymwars#Criticism) such as the German _Telemediengesetz_ federal law, which makes anonymous access to online services a legal requirement".

Finally, I'd like to observe that several high-profile Go community members and contributors have used pseudonyms exclusively during their tenures. Notably, the atom symbol ⚛  (0xe2.0x9a.0x9b) and mhhcbon.

In summary, there is no good reason to have this policy, and many good reasons to be rid of it. Let's be rid of it, please. Thanks for your consideration.